### PR TITLE
Add black, isort and pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 .vscode
 .python-version
+venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.7.0
+    hooks:
+      - id: isort
+        pass_filenames: false
+        args: ["-c", "redata", "tests"]
+
+  - repo: https://github.com/psf/black
+    rev: 19.10b0 # Replace by any tag/version: https://github.com/psf/black/tags
+    hooks:
+      - id: black
+        args: ["--check", "redata", "tests"]
+        language_version: python3 # Should be a command that runs python3.6+

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
     extras_require={
         'dev': [
             'isort',
-            'black'
+            'black',
+            'pre-commit'
         ]
     },
     entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,12 @@ setup(
         'alembic',
         'scipy'
     ],
+    extras_require={
+        'dev': [
+            'isort',
+            'black'
+        ]
+    },
     entry_points = {
         'console_scripts': ['redata=redata.command_line:main'],
     },


### PR DESCRIPTION
Just added `isort`, `black` and `pre-commit` as `dev` extra dependencies. In order to install them one should do the following:
`pip install -e '.[dev]'`

To enable pre-commit hooks at your project root do the following:
`pre-commit install`

These hooks are currently enabled in a "check-mode", so until after all files are formatted we might use `git commit` with `--no-verify` flag.

Also, I deliberately omitted any configuration because it's usually a question of argument, we might want to do it later.

Also, fixes #21 