### PR TITLE
Assigning the dag to the task is redundant.

### DIFF
--- a/redata/dags/schedule_checks.py
+++ b/redata/dags/schedule_checks.py
@@ -120,7 +120,7 @@ with DAG(
     is_paused_upon_creation=False,
 ) as dag_run:
 
-    PythonOperator(task_id="process_run", python_callable=process_run, dag=dag_run)
+    PythonOperator(task_id="process_run", python_callable=process_run)
 
 
 def add_run():
@@ -144,4 +144,4 @@ with DAG(
     is_paused_upon_creation=False,
 ) as dag_generate:
 
-    PythonOperator(task_id="add_run", python_callable=add_run, dag=dag_generate)
+    PythonOperator(task_id="add_run", python_callable=add_run)


### PR DESCRIPTION
## What
Cleaning up according to best practices.

## How
when instantiating a DAG object through a context manager, assigning the dag to the task is redundant.
Check out the (airflow) author blog post about that: https://marclamberti.com/blog/apache-airflow-with-statement/

